### PR TITLE
Add Travis jobs for OCaml 4.06 and 4.07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ env:
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
 script:
   - bash -ex .travis-opam.sh

--- a/lib/pb.ml
+++ b/lib/pb.ml
@@ -266,14 +266,14 @@ let read_contents : (key, string list) Hashtbl.t Angstrom.t =
   
 let read_field : type a. a field_type -> a Angstrom.t = 
   let open Angstrom in function
-    | Fixed64 -> LE.int64 >>| UInt64.of_int64
-    | Sfixed64 -> LE.int64
-    | Double -> LE.int64 >>| Int64.float_of_bits
+    | Fixed64 -> LE.any_int64 >>| UInt64.of_int64
+    | Sfixed64 -> LE.any_int64
+    | Double -> LE.any_int64 >>| Int64.float_of_bits
     | String -> read_string
     | Bytes -> read_bytes
-    | Fixed32 -> LE.int32 >>| UInt32.of_int32
-    | Sfixed32 -> LE.int32
-    | Float -> LE.int32 >>| Int32.float_of_bits
+    | Fixed32 -> LE.any_int32 >>| UInt32.of_int32
+    | Sfixed32 -> LE.any_int32
+    | Float -> LE.any_int32 >>| Int32.float_of_bits
     | Varint -> read_varint
     | Int32 -> read_int32
     | Int64 -> read_varint >>| UInt64.to_int64

--- a/opam
+++ b/opam
@@ -19,6 +19,6 @@ depends: [
   "integers"
   "base-bytes"
   "result"
-  "angstrom" {>= "0.7.0"}
+  "angstrom" {>= "0.10.0"}
   "faraday"
 ]


### PR DESCRIPTION
This is currently implemented atop #4, and can be rebased once that's merged.