### PR TITLE
Update for Angstrom 0.14.0

### DIFF
--- a/pb-plugin.opam
+++ b/pb-plugin.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.11"}
   "integers"
   "batteries"
-  "angstrom" {>= "0.10.0"}
+  "angstrom" {>= "0.14.0"}
   "faraday"
   "ounit" {with-test & >= "2.0"}
 ]

--- a/pb-plugin/src/pb_plugin.ml
+++ b/pb-plugin/src/pb_plugin.ml
@@ -276,7 +276,7 @@ let run msg =
 
 let main () =
   let stdin_buf = BatIO.(read_all stdin) in
-  match Angstrom.parse_string (Pb.read M.CodeGeneratorRequest.T.t) stdin_buf with
+  match Angstrom.(parse_string ~consume:Prefix) (Pb.read M.CodeGeneratorRequest.T.t) stdin_buf with
     Result.Error e -> failf "Error parssing request: %s" e
   | Result.Ok msg -> print_string (Faraday.serialize_to_string
                                      (Pb.write (run msg)))

--- a/pb-plugin/test/test.ml
+++ b/pb-plugin/test/test.ml
@@ -11,7 +11,7 @@ module C = Comprehensive
 let msg_to_string m = Faraday.serialize_to_string (Pb.write m)
 
 let read_from_string p s =
-  match Angstrom.parse_string p s with
+  match Angstrom.(parse_string ~consume:Prefix) p s with
   | Result.Error _ -> Printf.kprintf failwith "parse failure (%s)" s
   | Result.Ok v -> v
 

--- a/pb.opam
+++ b/pb.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "dune" {>= "1.11"}
   "integers"
-  "angstrom" {>= "0.10.0"}
+  "angstrom" {>= "0.14.0"}
   "faraday"
   "ounit" {with-test & >= "2.0"}
 ]

--- a/pb/test/test.ml
+++ b/pb/test/test.ml
@@ -18,7 +18,7 @@ let to_string t v =
 let msg_to_string m = Faraday.serialize_to_string (write m)
 
 let read_from_string p s =
-  match Angstrom.parse_string p s with
+  match Angstrom.(parse_string ~consume:Prefix) p s with
   | Result.Error _ -> Printf.kprintf failwith "parse failure (%s)" s
   | Result.Ok v -> v
 


### PR DESCRIPTION
[Since 0.14.0](https://github.com/inhabitedtype/angstrom/releases/tag/0.14.0), `Angstrom.parse_string` now takes a mandatory `~consume` argument (https://github.com/inhabitedtype/angstrom/pull/196)